### PR TITLE
Remove comma that was preventing SBT from loading the build definition.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -18,7 +18,7 @@ object Build extends Build {
       fork := true,
       exportJars := true,
 
-      addCompilerPlugin("org.scalamacros" % "paradise" % "2.0.0-M1" cross CrossVersion.full),
+      addCompilerPlugin("org.scalamacros" % "paradise" % "2.0.0-M1" cross CrossVersion.full)
     )
 
   lazy val root: Project = Project("root", file("."),


### PR DESCRIPTION
There was error when starting SBT:
  "project\Build.scala:22: illegal start of simple expression".

I did a simple fix by removing the extra comma. The fix is on a separate branch called `fix-build', so not to mess up your master branch if you have some unpushed changes.

Jarek
