### PR TITLE
Removes debugging statement

### DIFF
--- a/core-macros/src/main/scala/scalafxml/core/macros/sfxmlMacro.scala
+++ b/core-macros/src/main/scala/scalafxml/core/macros/sfxmlMacro.scala
@@ -158,8 +158,6 @@ object sfxmlMacro {
     // from the annotated class
     val q"class $name(...$argss) extends $baseClass with ..$traits { ..$body }" = annottees.map(_.tree).head
 
-    println(s"Compiling ScalaFXML proxy class for $name")
-
     /** Bindable public JavaFX variables for the proxy,
       * generated from the constructor arguments of the controller
       * which have a ScalaFX type


### PR DESCRIPTION
Removes statement, that will be printed to the console during compilation. In IntelliJ this output is classified, as a scalac warning, which it isn't. In order to avoid confusion and minimize the information overload, this statement is removed.